### PR TITLE
V3.2 anarsoul

### DIFF
--- a/arch/arm/mach-pxa/z2.c
+++ b/arch/arm/mach-pxa/z2.c
@@ -441,7 +441,7 @@ static struct gpio_keys_button z2_pxa_buttons[] = {
 	{
 		.code		= KEY_POWER,
 		.gpio		= GPIO1_ZIPITZ2_POWER_BUTTON,
-		.active_low	= 0,
+		.active_low	= 1,
 		.desc		= "Power Button",
 		.wakeup		= 1,
 		.type		= EV_KEY,


### PR DESCRIPTION
Hi Vasily,

The press and release events were not getting through to userspace during the suspend/wakeup cycle.  Additionally, the press event was reported as a release and the release was reported as a press.

I needed to capture the separate events so the power button can be used for both power off and suspend.  I reversed the power button's active value to resolve the problems.

Mark Majeres 
